### PR TITLE
fix: adjusted requirements.txt for Streamlit deployment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -99,7 +99,7 @@ pillow
 platformdirs
 prometheus-client
 prompt-toolkit
-protobuf
+protobuf==3.20.5
 psutil
 pure-eval
 pyarrow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 absl-py
-altair
+altair<5
 anyio
 argon2-cffi
 argon2-cffi-bindings

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ nest-asyncio
 nltk
 notebook
 notebook_shim
-numpy
+numpy==1.26.4
 oauthlib
 opt-einsum
 optree

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,7 +99,7 @@ pillow
 platformdirs
 prometheus-client
 prompt-toolkit
-protobuf==3.20.5
+protobuf~=3.19.0
 psutil
 pure-eval
 pyarrow


### PR DESCRIPTION
The following changes were done to `requirements.txt`:

```
-altair
+altair<5

-numpy
+numpy==1.26.4

-protobuf	
+protobuf~=3.19.0
```